### PR TITLE
Add headless example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Headless Example",
+      "program": "${workspaceFolder}/bin/headless",
+      "args": [],
+      "cwd": "${workspaceFolder}/bin",
+      "env": {
+        "LD_LIBRARY_PATH": "wgpu-64-debug"
+      }
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "args": [],
       "cwd": "${workspaceFolder}/bin",
       "env": {
-        "LD_LIBRARY_PATH": "wgpu-64-debug"
+        "LD_LIBRARY_PATH": "wgpu-64-debug",
+        "RUST_BACKTRACE": "1"
       }
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "name": "Debug Headless Example",
       "program": "${workspaceFolder}/bin/headless",
       "args": [],
-      "cwd": "${workspaceFolder}/bin",
+      "cwd": "${workspaceFolder}",
       "env": {
         "LD_LIBRARY_PATH": "wgpu-64-debug",
         "RUST_BACKTRACE": "1"

--- a/examples/headless/dub.json
+++ b/examples/headless/dub.json
@@ -9,6 +9,7 @@
   "targetType": "executable",
   "targetPath": "../../bin",
   "dependencies": {
+    "imageformats": "~>7.0.2",
     "wgpu-d": {
       "path": "../.."
     }

--- a/examples/headless/dub.selections.json
+++ b/examples/headless/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"imageformats": "7.0.2",
+		"wgpu-d": {"path":"../.."}
+	}
+}

--- a/examples/headless/source/app.d
+++ b/examples/headless/source/app.d
@@ -1,6 +1,93 @@
 import std.stdio;
 
+import wgpu.api;
+
 void main()
 {
-	writeln("Edit source/app.d to start your project.");
+  // Adapted from https://github.com/rukai/wgpu-rs/blob/f6123e4fe89f74754093c07b476099623b76dd08/examples/capture/main.rs
+  writeln("Headless (windowless) Example");
+
+	auto adapter = Adapter(RequestAdapterOptions(PowerPreference.Default));
+
+  assert(adapter.ready, "Adapter is not ready");
+  writefln("Adapter info: %s", adapter.info);
+  writefln("Adapter limits: %s", adapter.limits);
+
+  auto device = adapter.requestDevice(Limits());
+  writefln("Device limits: %s", device.limits);
+
+  const width = 300;
+  const height = 400;
+
+  // https://github.com/rukai/wgpu-rs/blob/f6123e4fe89f74754093c07b476099623b76dd08/examples/capture/main.rs#L53
+  const bytesPerPixel = uint.sizeof;
+  const unpaddedBytesPerRow = width * bytesPerPixel;
+  const alignment = COPY_BYTES_PER_ROW_ALIGNMENT;
+  const paddedBytesPerRowPadding = (alignment - unpaddedBytesPerRow % alignment) % alignment;
+  const paddedBytesPerRow = unpaddedBytesPerRow + paddedBytesPerRowPadding;
+
+  // The output buffer lets us retrieve data as an array
+  auto outputBuffer = device.createBuffer(BufferDescriptor(
+    null,
+    paddedBytesPerRow * height,
+    BufferUsage.mapRead | BufferUsage.copyDst,
+    false
+  ));
+
+  // The render pipeline renders data into this texture
+  auto textureExtent = Extent3d(width, height, 1);
+  auto texture = device.createTexture(TextureDescriptor(
+    null,
+    textureExtent,
+    1, // Mip level count
+    1, // Sample count
+    TextureDimension.D2,
+    TextureFormat.Rgba8UnormSrgb,
+    TextureUsage.outputAttachment | TextureUsage.copySrc,
+  ));
+  auto textureView = texture.createDefaultView();
+
+  // Set the background to red
+  auto encoder = device.createCommandEncoder(CommandEncoderDescriptor());
+  auto colorAttachment = RenderPassColorAttachmentDescriptor(
+    textureView.id,
+    0, // Resolve target
+    PassChannel_Color(
+      LoadOp.Clear,
+      StoreOp.Store,
+      Color(1, 0, 0, 1), // Red
+      false // Is *not* read only
+    )
+  );
+
+  encoder.beginRenderPass(RenderPassDescriptor(
+    &colorAttachment,
+    1,
+    null // depth stencil attachment
+  ));
+  // Copy the data from the texture to the buffer
+  encoder.copyTextureToBuffer(
+    TextureCopyView(
+      texture.id,
+      0, // Mip level
+      Origin3d(0, 0, 0),
+    ),
+    BufferCopyView(
+      outputBuffer.id,
+      TextureDataLayout(
+        0, // Offset
+        paddedBytesPerRow, // Bytes per row
+        0 // Rows per image
+      ),
+    ),
+    textureExtent
+  );
+  auto commandBuffer = encoder.finish();
+  device.queue.submit(commandBuffer);
+
+  device.poll(true); // Force wait for a frame to render
+
+  // TODO: Write a bmp or png of the output
+
+  // outputBuffer.unmap();
 }

--- a/examples/headless/source/app.d
+++ b/examples/headless/source/app.d
@@ -89,5 +89,5 @@ void main()
 
   // TODO: Write a bmp or png of the output
 
-  // outputBuffer.unmap();
+  outputBuffer.unmap();
 }

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -92,6 +92,8 @@ alias RenderPipelineDescriptor = WGPURenderPipelineDescriptor;
 alias ComputePipelineDescriptor = WGPUComputePipelineDescriptor;
 /// Describes a `RenderPass`.
 alias RenderPassDescriptor = WGPURenderPassDescriptor;
+/// Describes a color attachment to a `RenderPass`.
+alias RenderPassColorAttachmentDescriptor = WGPURenderPassColorAttachmentDescriptor;
 /// Describes a `ComputePass`.
 alias ComputePassDescriptor = WGPUComputePassDescriptor;
 /// Describes a `CommandBuffer`.

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -218,6 +218,13 @@ struct Device {
     return Queue(wgpu_device_get_default_queue(id));
   }
 
+  /// Check for resource cleanups and mapping callbacks.
+  /// Params:
+  /// forceWait = Whether or not the call should block.
+  void poll(bool forceWait = false) {
+    wgpu_device_poll(id, forceWait);
+  }
+
   /// Creates a shader module from SPIR-V source code.
   ShaderModule createShaderModule(const ubyte[] spv) {
     import std.algorithm.iteration : map;

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -1,4 +1,4 @@
-/// An idiomatic D wrapper for wgpu-native.
+/// An idiomatic D wrapper for <a href="https://github.com/gfx-rs/wgpu-native">wgpu-native</a>.
 ///
 /// Authors: Chance Snow
 /// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
@@ -12,7 +12,8 @@ import std.traits : fullyQualifiedName;
 
 import wgpu.bindings;
 
-/// Version of wgpu-native this library binds.
+/// Version of <a href="https://github.com/gfx-rs/wgpu-native">wgpu-native</a> this library binds.
+/// See_Also: <a href="https://github.com/gfx-rs/wgpu-native/releases/tag/v0.6.0">github.com/gfx-rs/wgpu-native/releases/tag/v0.6.0</a>
 static const VERSION = "0.6.0";
 /// Buffer-Texture copies must have bytes_per_row aligned to this number.
 ///
@@ -104,14 +105,30 @@ public import wgpu.bindings: AddressMode, Backend, BindingType, BlendFactor, Ble
   PowerPreference, PresentMode, PrimitiveTopology, SType, StencilOperation, StoreOp, SwapChainStatus, TextureAspect,
   TextureComponentType, TextureDimension, TextureFormat, TextureViewDimension, VertexFormat;
 
+/// Describes the shader stages that a binding will be visible from.
+///
+/// These can be combined in a bitwise combination.
+///
+/// For example, something that is visible from both vertex and fragment shaders can be defined as:
+///
+/// `ShaderStage.vertex | ShaderStage.fragment`
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.ShaderStage.html">wgpu::ShaderStage</a>
 enum ShaderStage : WGPUShaderStage {
+  /// Binding is not visible from any shader stage.
   none = 0,
+  /// Binding is visible from the vertex shader of a render pipeline.
   vertex = 1,
+  /// Binding is visible from the fragment shader of a render pipeline.
   fragment = 2,
+  /// Binding is visible from the compute shader of a compute pipeline.
   compute = 4
 }
 
+/// Different ways that you can use a buffer.
+///
+/// The usages determine what kind of memory the buffer is allocated from and what actions the buffer can partake in.
+///
+/// These can be combined in a bitwise combination.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.BufferUsage.html">wgpu::BufferUsage</a>
 enum BufferUsage : WGPUBufferUsage {
   mapRead = 1,
@@ -125,6 +142,11 @@ enum BufferUsage : WGPUBufferUsage {
   indirect = 256
 }
 
+/// Different ways that you can use a texture.
+///
+/// The usages determine what kind of memory the texture is allocated from and what actions the texture can partake in.
+///
+/// These can be combined in a bitwise combination.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.TextureUsage.html">wgpu::TextureUsage</a>
 enum TextureUsage : WGPUTextureUsage {
   copySrc = 1,

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -143,7 +143,8 @@ extern (C) private void wgpu_request_adapter_callback(ulong id, void* data) {
 ///
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Adapter.html">wgpu::Adapter</a>
 struct Adapter {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 
   /// Requests a new Adapter, asynchronously.
   ///
@@ -202,7 +203,8 @@ struct Adapter {
 /// The `Device` is the responsible for the creation of most rendering and compute resources, as well as exposing `Queue` objects.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Device.html">wgpu::Device</a>
 struct Device {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
   /// label for this Device.
   string label;
 
@@ -300,7 +302,8 @@ struct Device {
 /// A Surface may be created with `Surface.create`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Surface.html">wgpu::Surface</a>
 struct Surface {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// A handle to a swap chain.
@@ -309,7 +312,8 @@ struct Surface {
 /// A `SwapChain` may be created with `Device.createSwapChain`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.SwapChain.html">wgpu::SwapChain</a>
 struct SwapChain {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 
   /// Returns the next texture to be presented by the swapchain for drawing.
   SwapChainOutput getNextTexture() {
@@ -357,7 +361,8 @@ const struct SwapChainOutput {
 /// A handle to a GPU-accessible buffer.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Buffer.html">wgpu::Buffer</a>
 struct Buffer {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
   /// Size of this Buffer, in bytes.
   size_t size;
 }
@@ -365,7 +370,8 @@ struct Buffer {
 /// A handle to a texture on the GPU.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Texture.html">wgpu::Texture</a>
 struct Texture {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 
   /// Creates a view of this texture.
   TextureView createView(const TextureViewDescriptor descriptor) {
@@ -383,7 +389,8 @@ struct Texture {
 /// A `TextureView` object describes a texture and associated metadata needed by a `RenderPipeline` or `BindGroup`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.TextureView.html">wgpu::TextureView</a>
 struct TextureView {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// A handle to a sampler.
@@ -394,13 +401,15 @@ struct TextureView {
 /// See the documentation for `SamplerDescriptor` for more information.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Sampler.html">wgpu::Sampler</a>
 struct Sampler {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// A Queue executes finished C`ommandBuffer` objects.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.Queue.html">wgpu::Queue</a>
 struct Queue {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 
   /// Submits a series of finished command buffers for execution.
   void submit(CommandBuffer[] commands) {
@@ -418,7 +427,8 @@ struct Queue {
 /// A `CommandBuffer` is obtained by recording a series of commands to a `CommandEncoder` and then calling `CommandEncoder.finish`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.CommandBuffer.html">wgpu::CommandBuffer</a>
 struct CommandBuffer {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// A handle to a compiled shader module.
@@ -427,7 +437,8 @@ struct CommandBuffer {
 /// Shader modules are used to define programmable stages of a pipeline.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.ShaderModule.html">wgpu::ShaderModule</a>
 struct ShaderModule {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// An object that encodes GPU operations.
@@ -437,7 +448,8 @@ struct ShaderModule {
 /// When finished recording, call `CommandEncoder.finish` to obtain a `CommandBuffer` which may be submitted for execution.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.CommandEncoder.html">wgpu::CommandEncoder</a>
 struct CommandEncoder {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
   /// Describes a `CommandBuffer`.
   const CommandBufferDescriptor descriptor;
 
@@ -468,7 +480,8 @@ struct CommandEncoder {
 /// with `RenderPass.setBindGroup`, or to a `ComputePass` with `ComputePass.setBindGroup`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.BindGroup.html">wgpu::BindGroup</a>
 struct BindGroup {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// An opaque handle to a binding group layout.
@@ -479,7 +492,8 @@ struct BindGroup {
 /// `PipelineLayoutDescriptor`, which can be used to create a `PipelineLayout`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.BindGroupLayout.html">wgpu::BindGroupLayout</a>
 struct BindGroupLayout {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// An opaque handle to a pipeline layout.
@@ -487,7 +501,8 @@ struct BindGroupLayout {
 /// A `PipelineLayout` object describes the available binding groups of a pipeline.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.PipelineLayout.html">wgpu::PipelineLayout</a>
 struct PipelineLayout {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// A handle to a rendering (graphics) pipeline.
@@ -496,7 +511,8 @@ struct PipelineLayout {
 /// A `RenderPipeline` may be created with `Device.createRenderPipeline`.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.RenderPipeline.html">wgpu::RenderPipeline</a>
 struct RenderPipeline {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 
   ~this() {
     wgpu_render_pipeline_destroy(id);
@@ -592,7 +608,8 @@ struct RenderPass {
 /// A handle to a compute pipeline.
 /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.ComputePipeline.html">wgpu::ComputePipeline</a>
 struct ComputePipeline {
-  package WgpuId id;
+  /// Handle identifier.
+  WgpuId id;
 }
 
 /// An in-progress recording of a compute pass.

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -398,6 +398,15 @@ struct Buffer {
   WgpuId id;
   /// Size of this Buffer, in bytes.
   size_t size;
+
+  ~this() {
+    wgpu_buffer_destroy(id);
+  }
+
+  /// Flushes any pending write operations and unmaps the buffer from host memory.
+  void unmap() {
+    wgpu_buffer_unmap(id);
+  }
 }
 
 /// A handle to a texture on the GPU.

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -429,13 +429,13 @@ struct Buffer {
     return data[0 .. size];
   }
 
-  /// Read this `Buffer`'s asynchronously.
+  /// Map the buffer for reading asynchronously.
   /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.BufferSlice.html#method.map_async">wgpu::BufferSlice::map_async</a>
   void mapReadAsync(BufferAddress start, BufferAddress size) {
     wgpu_buffer_map_read_async(id, start, size, &wgpu_buffer_map_callback, cast(ubyte*) &this);
   }
 
-  /// Write to this `Buffer` asynchronously.
+  /// Map the buffer for writing asynchronously.
   /// See_Also: <a href="https://docs.rs/wgpu/0.6.0/wgpu/struct.BufferSlice.html#method.map_async">wgpu::BufferSlice::map_async</a>
   void mapWriteAsync(BufferAddress start, BufferAddress size) {
     wgpu_buffer_map_write_async(id, start, size, &wgpu_buffer_map_callback, cast(ubyte*) &this);

--- a/source/wgpu/api.d
+++ b/source/wgpu/api.d
@@ -261,15 +261,15 @@ struct Device {
   }
 
   /// Creates a shader module from SPIR-V source code.
-  ShaderModule createShaderModule(const ubyte[] spv) {
+  ShaderModule createShaderModule(const byte[] spv) {
     import std.algorithm.iteration : map;
     import std.array : array;
 
     const bytes = spv.map!(byte_ => byte_.to!(const uint)).array;
-    return ShaderModule(wgpu_device_create_shader_module(id, WGPUShaderSource(
-      cast(const(uint)*) &bytes,
-      spv.length
-    )));
+    return ShaderModule(wgpu_device_create_shader_module(
+      id,
+      WGPUShaderSource(bytes.ptr, spv.length))
+    );
   }
 
   /// Creates an empty `CommandEncoder`.
@@ -466,8 +466,8 @@ struct Queue {
     import std.algorithm.iteration : map;
     import std.array : array;
 
-    auto commandIds = commandBuffers.map!(c => c.id).array;
-    wgpu_queue_submit(id, cast(const(c_ulong)*) &commandIds, commandBuffers.length);
+    const commandBufferIds = commandBuffers.map!(c => c.id).array;
+    wgpu_queue_submit(id, commandBufferIds.ptr, commandBuffers.length);
   }
 }
 
@@ -587,7 +587,7 @@ struct RenderPass {
     import std.array : array;
 
     auto offsetsAsUints = offsets.map!(offset => offset.to!(const uint)).array;
-    wgpu_render_pass_set_bind_group(instance, index, bindGroup.id, cast(const(uint)*) &offsetsAsUints, offsets.length);
+    wgpu_render_pass_set_bind_group(instance, index, bindGroup.id, offsetsAsUints.ptr, offsets.length);
   }
 
   /// Sets the active render pipeline.
@@ -678,7 +678,7 @@ struct ComputePass {
     import std.array : array;
 
     auto offsetsAsUints = offsets.map!(offset => offset.to!(const uint)).array;
-    wgpu_compute_pass_set_bind_group(instance, index, bindGroup.id, cast(const(uint)*) &offsetsAsUints, offsets.length);
+    wgpu_compute_pass_set_bind_group(instance, index, bindGroup.id, offsetsAsUints.ptr, offsets.length);
   }
 
   /// Sets the active compute pipeline.

--- a/views/nav.html
+++ b/views/nav.html
@@ -13,7 +13,7 @@
 </style>
 <nav id="main-nav">
   <h1>
-    <img id="logo" src="/images/logo.png" alt="wgpu Logo">
+    <img id="logo" src="https://chances.github.io/wgpu-d/images/logo.png" alt="wgpu Logo">
     <span>D Bindings</span>
   </h1>
   <ul style="list-style: none; padding: 0;">


### PR DESCRIPTION
- Add a windowless example that clears the background to red
- Add `Device.poll` method
- Add `getMappedRange`, `mapReadAsync`, and `mapWriteAsync` methods to `Buffer`
- Add `Buffer.unmap` method